### PR TITLE
fix: self is not defined error

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,7 +19,7 @@ const nextConfig = {
     	config,
     { buildId, dev, isServer, defaultLoaders, nextRuntime, webpack }
   ) => {
-  config.output.globalObject = 'this'
+    // config.output.globalObject = 'this'
     // Important: return the modified config
     return config
   },

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,10 +1,16 @@
 'use client'
 
 import React, { useState, useCallback } from 'react';
-import TokenInput from 'react-customize-token-input'
+import dynamic from 'next/dynamic';
+
+// https://nextjs.org/docs/pages/building-your-application/optimizing/lazy-loading#with-no-ssr
+const TokenInput = dynamic(
+  () => import('react-customize-token-input'),
+  { ssr: false }
+);
 
 const Example = () => {
-  const [values, setValues] = useState([]);
+  const [values, setValues] = useState(['hello', 'world']);
 
   const handleTokenValuesChange = useCallback(
     (newTokenValues) => {
@@ -30,7 +36,7 @@ const Example = () => {
 export default function Home() {
   return (
     <main>
-	<Example />
+	    <Example />
     </main>
   );
 }


### PR DESCRIPTION
Applying nextJs dynamic import with no ssr to import TokenInput to resolve the self is not defined error.

https://nextjs.org/docs/pages/building-your-application/optimizing/lazy-loading#with-no-ssr

Reference: [Fixing ‘self’ is not defined error in Next.js when importing client-side libraries](https://www.slingacademy.com/article/fixing-self-is-not-defined-error-in-nextjs/)